### PR TITLE
Publish to PyPI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,111 @@
+Contributing to agio-cli
+========================
+
+## Install development environment
+Set up a development virtual environment.
+```console
+$ python3 -m venv .venv
+$ source env/bin/activate
+$ pip install --editable .[dev,test]
+```
+
+A `agio` entry point script is installed in your virtual environment.
+```console
+$ which agio
+/Users/awdeorio/src/mailmerge/.venv/bin/agio
+```
+
+## Testing and code quality
+Run unit tests
+```console
+$ pytest
+$ pytest -vv --log-cli-level=DEBUG  # More output
+```
+
+Measure unit test case coverage
+```console
+$ pytest --cov ./agiocli --cov-report term-missing
+```
+
+Test code style
+```console
+$ pycodestyle agiocli tests setup.py
+$ pydocstyle agiocli tests setup.py
+$ pylint agiocli tests setup.py
+$ check-manifest
+```
+
+Run linters and tests in a clean environment.  This will automatically create a temporary virtual environment.
+```console
+$ tox -e py3
+```
+
+## Release procedure
+Update your local `develop` branch.  Make sure it's clean.
+```
+git fetch
+git checkout develop
+git rebase
+git status
+```
+
+Test
+```
+tox -e py3
+```
+
+Update version
+```
+$EDITOR setup.py
+git commit -m "version bump" setup.py
+git push origin develop
+```
+
+Update main branch
+```
+git fetch
+git checkout main
+git rebase
+git merge --no-ff origin/develop
+```
+
+Build distribution binary and source tarball locally
+```
+rm -rf dist
+python3 setup.py sdist bdist_wheel
+ls dist
+agiocli-0.1.0-py3-none-any.whl  agiocli-0.1.0.tar.gz
+```
+
+Tag a release
+```
+git tag -a X.Y.Z
+grep version= setup.py
+git describe
+git push --tags origin main
+```
+
+Deploy to Test PyPI, then browse to https://test.pypi.org/project/agiocli/
+```
+twine upload --sign --repository-url https://test.pypi.org/legacy/ dist/*
+```
+
+Test install.  It will install, but not run because we didn't install deps.
+```
+python3 -m venv testenv
+source testenv/bin/activate
+pip install --index-url https://test.pypi.org/simple/ --no-deps agiocli
+agio --version  # Expect module not found error
+deactivate
+```
+
+Deploy to PyPI, then browse to https://pypi.org/project/agiocli/
+```
+twine upload --sign dist/*
+```
+
+Test install from new PyPI deploy
+```
+pip3 install --upgrade agiocli
+agio --version
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,70 +42,73 @@ $ tox -e py3
 
 ## Release procedure
 Update your local `develop` branch.  Make sure it's clean.
-```
-git fetch
-git checkout develop
-git rebase
-git status
+```console
+$ git fetch
+$ git checkout develop
+$ git rebase
+$ git status
 ```
 
 Test
-```
-tox -e py3
+```console
+$ tox -e py3
 ```
 
 Update version
-```
-$EDITOR setup.py
-git commit -m "version bump" setup.py
-git push origin develop
+```console
+$ $EDITOR setup.py
+$ git commit -m "version bump" setup.py
+$ git push origin develop
 ```
 
 Update main branch
-```
-git fetch
-git checkout main
-git rebase
-git merge --no-ff origin/develop
+```console
+$ git fetch
+$ git checkout main
+$ git rebase
+$ git merge --no-ff origin/develop
 ```
 
 Build distribution binary and source tarball locally
-```
-rm -rf dist
-python3 setup.py sdist bdist_wheel
-ls dist
+```console
+$ rm -rf dist
+$ python3 setup.py sdist bdist_wheel
+$ ls dist
 agiocli-0.1.0-py3-none-any.whl  agiocli-0.1.0.tar.gz
 ```
 
 Tag a release
-```
-git tag -a X.Y.Z
-grep version= setup.py
-git describe
-git push --tags origin main
+```console
+$ git tag -a X.Y.Z
+$ grep version= setup.py
+    version="X.Y.Z",
+$ git describe
+X.Y.Z
+$ git push --tags origin main
 ```
 
 Deploy to Test PyPI, then browse to https://test.pypi.org/project/agiocli/
-```
-twine upload --sign --repository-url https://test.pypi.org/legacy/ dist/*
+```console
+$ twine upload --sign --repository-url https://test.pypi.org/legacy/ dist/*
 ```
 
 Test install.  It will install, but not run because we didn't install deps.
-```
-python3 -m venv testenv
-source testenv/bin/activate
-pip install --index-url https://test.pypi.org/simple/ --no-deps agiocli
-agio --version  # Expect module not found error
-deactivate
+```console
+$ python3 -m venv testenv
+$ source testenv/bin/activate
+$ pip install --index-url https://test.pypi.org/simple/ --no-deps agiocli
+$ agio --version  # Expect module not found error
+$ deactivate
 ```
 
 Deploy to PyPI, then browse to https://pypi.org/project/agiocli/
-```
-twine upload --sign dist/*
+```console
+$ twine upload --sign dist/*
 ```
 
 Test install from new PyPI deploy
-```
-pip3 install --upgrade agiocli
-agio --version
+```console
+$ pip3 install --upgrade agiocli
+$ agio --version
+agio, version X.Y.Z
 ```

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include LICENSE
 include MANIFEST.in
 include README.md
+include CONTRIBUTING.md
 include .pylintrc
 graft tests
 include test

--- a/README.md
+++ b/README.md
@@ -21,31 +21,7 @@ $ agiocli
 directory.
 
 ## Contributing
-Install
-```console
-$ python3 -m venv .venv
-$ source .venv/bin/activate
-$ pip install -e .[dev,test]
-```
-
-Run tests
-```console
-$ pytest
-$ pytest -vv --log-cli-level=DEBUG
-```
-
-Test code style
-```console
-$ pycodestyle agiocli tests setup.py
-$ pydocstyle agiocli tests setup.py
-$ pylint agiocli tests setup.py
-$ check-manifest
-```
-
-Regression, including tests and style checks
-```console
-$ tox
-```
+Contributions from the community are welcome! Check out the [guide for contributing](CONTRIBUTING.md).
 
 ## Acknowledgments
 Autograder.io CLI is written by Andrew DeOrio <awdeorio@umich.edu>.  Justin Applefield removed bugs and contributed features.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ First, [obtain a token](#obtaining-a-token) (below).
 
 ```console
 $ pip install agiocli
-$ agiocli
+$ agio
 ```
 
 ## Obtaining a Token

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setuptools.setup(
     install_requires=[
         "click",
         "pick",
+        "python-dateutil",
         "requests",
     ],
     extras_require={
@@ -45,7 +46,6 @@ setuptools.setup(
             "pytest",
             "pytest-cov",
             "pytest-mock",
-            "python-dateutil",
             "requests-mock",
         ],
     },


### PR DESCRIPTION
Publish to PyPI.

Closes #2

## Validation
- GitHub repo should be public https://github.com/eecs485staff/agio-cli
- PyPI should be live https://pypi.org/project/agiocli/
- Install from PyPI into a clean virtual environment using instructions in the README
