### PR TITLE
Token download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,10 @@ Autograder.io CLI (`agio`) is a command line interface to [autograder.io](https:
 
 
 ## Quick start
-First, [obtain a token](#obtaining-a-token) (below).
-
 ```console
 $ pip install agiocli
 $ agio
 ```
-
-## Obtaining a Token
-1. Log in [autograder.io](https://autograder.io/) with your web browser
-2. Open browser developer tools
-3. Click on a course link
-4. In the developer console, click on a request, e.g., `my_roles/` or `projects/`)
-5. Under Request Headers, there is an Authorization entry that looks like "Token ". Copy the hex string and save it to the file `.agtoken` in your home
-directory.
 
 ## Contributing
 Contributions from the community are welcome! Check out the [guide for contributing](CONTRIBUTING.md).

--- a/agiocli/api_client.py
+++ b/agiocli/api_client.py
@@ -151,21 +151,28 @@ def get_api_token(token_filename: str) -> str:
     - If token_filename is an absolute path or a relative path that contains
       at least one directory, that file will be opened and the token read.
     """
-    token_not_found_msg = f"Token file not found: {token_filename}"
+    # Token filename provided and it does not exist
     if os.path.dirname(token_filename) and not os.path.isfile(token_filename):
-        raise TokenFileNotFound(token_not_found_msg)
+        raise TokenFileNotFound("Token file does not exist: {token_filename}")
 
     # Make sure that we're starting in a subdir of the home directory
-    if os.path.expanduser('~') not in os.path.abspath(os.curdir):
-        raise TokenFileNotFound(token_not_found_msg)
+    curdir = os.path.abspath(os.curdir)
+    if os.path.expanduser('~') not in curdir:
+        raise TokenFileNotFound(f"Invalid search path: {curdir}")
 
+    # Search, walking up the directory structure from PWD to home
     for dirname in walk_up_to_home_dir():
         filename = os.path.join(dirname, token_filename)
         if os.path.isfile(filename):
             with open(filename, encoding="utf8") as tokenfile:
                 return tokenfile.read().strip()
 
-    raise TokenFileNotFound(token_not_found_msg)
+    # Didn't find a token file
+    raise TokenFileNotFound(
+        f"Token file not found: {token_filename}.  Download a token from "
+        f"https://autograder.io/web/__apitoken__ and save it to "
+        f"~/{token_filename} or ./{token_filename}"
+    )
 
 
 def walk_up_to_home_dir() -> Iterator[str]:


### PR DESCRIPTION
Point users to web based token download when `.agtoken` is not found.

Closes #3

## Validation
Remove your `~/.agtoken`.  Try using `agio`.  Make sure that the error messages help you get a token.