### PR TITLE
CI Fixes

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # Local host configuration with one Python 3 version
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py36, py37, py38, py39, py310
 
 # GitHub Actions configuration with multiple Python versions
 # https://github.com/ymyzk/tox-gh-actions#tox-gh-actions-configuration
@@ -10,15 +10,18 @@ python =
   3.7: py37
   3.8: py38
   3.9: py39
+  3.10: py310
 
 # Run unit tests
+# HACK: Pydocstyle fails to find tests.  Invoke a shell to use a glob.
 [testenv]
 setenv =
   PYTHONPATH = {toxinidir}
+allowlist_externals = sh
 extras = test
 commands =
   pycodestyle agiocli tests setup.py
-  pydocstyle agiocli tests setup.py
+  sh -c "pydocstyle agiocli tests/* setup.py"
   pylint agiocli tests setup.py
   check-manifest
   pytest -vvs --cov agiocli


### PR DESCRIPTION
Include Python 3.10 in Tox config.  Fix a problem with pycodestyle finding tests.
