### PR TITLE
Default term

### DIFF
--- a/agiocli/__main__.py
+++ b/agiocli/__main__.py
@@ -52,6 +52,7 @@ def courses(ctx, course_arg, show_list, web):  # noqa: D301
     agio courses
     agio courses 109
     agio courses eecs485sp21
+    agio courses eecs485
 
     """
     try:

--- a/agiocli/__main__.py
+++ b/agiocli/__main__.py
@@ -52,7 +52,7 @@ def courses(ctx, course_arg, show_list, web):  # noqa: D301
     agio courses
     agio courses 109
     agio courses eecs485sp21
-    agio courses eecs485
+    agio courses eecs485[cur|current]
 
     """
     try:

--- a/agiocli/utils.py
+++ b/agiocli/utils.py
@@ -134,7 +134,8 @@ def parse_course_string(user_input):
         sp|s|spring|
         su|summer|
         sp/su|spsu|ss|spring/summer|
-        f|fa|fall|)
+        f|fa|fall|
+        cur|current|)
     [\s_-]*                     # Optional whitespace or delimiter
     (?P<year>\d{2,4}|)          # 2-4 digit year or empty string
     \s*                         # Optional trailing whitespace
@@ -144,14 +145,15 @@ def parse_course_string(user_input):
     if not match:
         sys.exit(f"Error: unsupported input format: '{user_input}'")
 
-    # User must provide either year and semester or neither
+    # User must provide either year and semester or neither.  Semester may be
+    # "cur" or "current."
     year = match.group("year")
     semester_abbrev = match.group("sem")
-    if bool(year) ^ bool(semester_abbrev):
+    if bool(year) ^ (semester_abbrev not in ["", "cur", "current"]):
         sys.exit(f"Error: unsupported input format: '{user_input}'")
 
-    # Default year and semester if none specified
-    if not year and not semester_abbrev:
+    # Default year and semester
+    if not year and semester_abbrev in ["", "cur", "current"]:
         today = dt.date.today()
         year = today.year
         semester_abbrev = MONTH_SEMESTER_NAME[today.month]

--- a/agiocli/utils.py
+++ b/agiocli/utils.py
@@ -43,6 +43,7 @@ MONTH_SEMESTER_NAME = {
     12: "Fall",
 }
 
+
 def dict_str(obj):
     """Format a dictionary as an indented string."""
     return json.dumps(obj, indent=4)

--- a/tests/test_courses.py
+++ b/tests/test_courses.py
@@ -122,3 +122,22 @@ def test_courses_shortcut(api_mock):
     assert result.exit_code == 0, result.output
     output_obj = json.loads(result.output)
     assert output_obj["pk"] == 109
+
+
+def test_courses_cur(api_mock):
+    """Verify courses subcommand with "current" shortcut input.
+
+    $ agio courses eecs485current
+
+    api_mock is a shared test fixture that mocks responses to REST API
+    requests.  It is implemented in conftest.py.
+
+    """
+    runner = click.testing.CliRunner()
+    result = runner.invoke(
+        main, ["courses", "eecs485current"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    output_obj = json.loads(result.output)
+    assert output_obj["pk"] == 109

--- a/tests/test_courses.py
+++ b/tests/test_courses.py
@@ -7,6 +7,7 @@ import json
 import textwrap
 import click
 import click.testing
+import freezegun
 from agiocli.__main__ import main
 
 

--- a/tests/test_courses.py
+++ b/tests/test_courses.py
@@ -124,20 +124,24 @@ def test_courses_shortcut(api_mock):
     assert output_obj["pk"] == 109
 
 
-def test_courses_cur(api_mock):
-    """Verify courses subcommand with "current" shortcut input.
+def test_courses_default_semester(api_mock):
+    """Verify courses subcommand with no semester/year shortcut input.
 
-    $ agio courses eecs485current
+    $ agio courses eecs485
 
     api_mock is a shared test fixture that mocks responses to REST API
     requests.  It is implemented in conftest.py.
 
     """
+    # Run agio, mocking the date to be Jun 2021.  The current course should be
+    # spring 2021  https://github.com/spulec/freezegun
     runner = click.testing.CliRunner()
-    result = runner.invoke(
-        main, ["courses", "eecs485current"],
-        catch_exceptions=False,
-    )
+    with freezegun.freeze_time("2021-06-15"):
+        result = runner.invoke(
+            main, ["courses", "eecs485"],
+            catch_exceptions=False,
+        )
+
     assert result.exit_code == 0, result.output
     output_obj = json.loads(result.output)
     assert output_obj["pk"] == 109

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -1,4 +1,5 @@
 """Unit tests for smart user input string matching."""
+import freezegun
 import pytest
 from agiocli import utils
 
@@ -89,6 +90,39 @@ def test_course_match_bad_year(search):
     """Bad year in pattern."""
     matches = utils.course_match(search, COURSES)
     assert not matches
+
+
+@pytest.mark.parametrize(
+    "search, expected_course_pk",
+    [
+        ("EECS 280", 111),
+        ("EECS 280 cur", 111),
+        ("EECS 280 current", 111),
+        ("eecs280", 111),
+        ("eecs280cur", 111),
+        ("eecs280current", 111),
+        ("eecs280-cur", 111),
+        ("eecs280-current", 111),
+        ("EECS 485", 109),
+        ("EECS 485 cur", 109),
+        ("EECS 485 current", 109),
+        ("eecs485", 109),
+        ("eecs485cur", 109),
+        ("eecs485current", 109),
+        ("eecs485-cur", 109),
+        ("eecs485-current", 109),
+
+    ]
+)
+def test_course_match_current(search, expected_course_pk):
+    """Auto select current semester."""
+    # Run course match, mocking the date to be June 2021
+    # https://github.com/spulec/freezegun
+    with freezegun.freeze_time("2021-06-15"):
+        matches = utils.course_match(search, COURSES)
+    assert len(matches) == 1
+    course = matches[0]
+    assert course["pk"] == expected_course_pk
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Support a course string without a semester, e.g., `eecs485`.

Closes #27