### PR TITLE
Replace options_map_func with pick.Option

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       # Define OS and Python versions to use. 3.x is the latest minor version.
       matrix:
-        python-version: ["3.6", "3.x"]  # 3.x is the latest minor version
+        python-version: ["3.7", "3.x"]  # 3.x is the latest minor version
         os: [ubuntu-latest]
 
     # Sequence of tasks for this job

--- a/agiocli/utils.py
+++ b/agiocli/utils.py
@@ -226,15 +226,15 @@ def get_course_smart(course_arg, client):
 
     # Get a list of courses sorted by year, semester and name
     courses = get_current_course_list(client)
-    courses_options = [pick.Option(course_str(x), x) for x in courses]
 
     # No course input from the user.  Show all courses and prompt the user.
     if not course_arg:
         if not courses:
             sys.exit("Error: No current courses, try 'agio courses -l'")
         else:
+            options = [pick.Option(course_str(x), x) for x in courses]
             selected_courses = pick.pick(
-                options=courses_options,
+                options=options,
                 title=("Select a course:"),
                 multiselect=False,
             )
@@ -378,13 +378,13 @@ def get_project_smart(project_arg, course_arg, client):
     projects = get_course_project_list(course, client)
     if not projects:
         sys.exit("Error: No projects for course, try 'agio courses -l'")
-    projects_options = [pick.Option(project_str(x), x) for x in projects]
 
     # No project input from the user.  Show all projects for current course and
     # and prompt the user.
     if not project_arg:
+        options = [pick.Option(project_str(x), x) for x in projects]
         selected_projects = pick.pick(
-            options=projects_options,
+            options=options,
             title="Select a project:",
             multiselect=False,
         )
@@ -574,14 +574,13 @@ def get_submission_smart(
     submissions = get_submission_list(group, client)
     if not submissions:
         sys.exit("Error: No submissions, try 'agio submissions -l'")
-    submissions_options = [pick.Option(submission_str(x), x)
-                           for x in submissions]
 
     # No submissions input from the user.  Show all submissions for this group
     # and prompt the user.
     if not submission_arg:
+        options = [pick.Option(submission_str(x), x) for x in submissions]
         selected_submissions = pick.pick(
-            options=submissions_options,
+            options=options,
             title="Select a submission:",
             multiselect=False,
         )

--- a/agiocli/utils.py
+++ b/agiocli/utils.py
@@ -574,7 +574,8 @@ def get_submission_smart(
     submissions = get_submission_list(group, client)
     if not submissions:
         sys.exit("Error: No submissions, try 'agio submissions -l'")
-    submissions_options = [pick.Option(submission_str(x), x) for x in submissions]
+    submissions_options = [pick.Option(submission_str(x), x)
+                           for x in submissions]
 
     # No submissions input from the user.  Show all submissions for this group
     # and prompt the user.

--- a/agiocli/utils.py
+++ b/agiocli/utils.py
@@ -226,6 +226,7 @@ def get_course_smart(course_arg, client):
 
     # Get a list of courses sorted by year, semester and name
     courses = get_current_course_list(client)
+    courses_options = [pick.Option(course_str(x), x) for x in courses]
 
     # No course input from the user.  Show all courses and prompt the user.
     if not course_arg:
@@ -233,9 +234,8 @@ def get_course_smart(course_arg, client):
             sys.exit("Error: No current courses, try 'agio courses -l'")
         else:
             selected_courses = pick.pick(
-                options=courses,
+                options=courses_options,
                 title=("Select a course:"),
-                options_map_func=course_str,
                 multiselect=False,
             )
             assert selected_courses
@@ -378,14 +378,14 @@ def get_project_smart(project_arg, course_arg, client):
     projects = get_course_project_list(course, client)
     if not projects:
         sys.exit("Error: No projects for course, try 'agio courses -l'")
+    projects_options = [pick.Option(project_str(x), x) for x in projects]
 
     # No project input from the user.  Show all projects for current course and
     # and prompt the user.
     if not project_arg:
         selected_projects = pick.pick(
-            options=projects,
+            options=projects_options,
             title="Select a project:",
-            options_map_func=project_str,
             multiselect=False,
         )
         assert selected_projects
@@ -574,14 +574,14 @@ def get_submission_smart(
     submissions = get_submission_list(group, client)
     if not submissions:
         sys.exit("Error: No submissions, try 'agio submissions -l'")
+    submissions_options = [pick.Option(submission_str(x), x) for x in submissions]
 
     # No submissions input from the user.  Show all submissions for this group
     # and prompt the user.
     if not submission_arg:
         selected_submissions = pick.pick(
-            options=submissions,
+            options=submissions_options,
             title="Select a submission:",
-            options_map_func=submission_str,
             multiselect=False,
         )
         assert selected_submissions

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setuptools.setup(
             "requests-mock",
         ],
     },
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     entry_points={
         "console_scripts": [
             "agio = agiocli.__main__:main",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
     ],
     install_requires=[
         "click",
-        "pick",
+        "pick>=2.0.0",
         "python-dateutil",
         "requests",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 # Local host configuration with one Python 3 version
 [tox]
-envlist = py36, py37, py38, py39, py310
+envlist = py37, py38, py39, py310
 
 # GitHub Actions configuration with multiple Python versions
 # https://github.com/ymyzk/tox-gh-actions#tox-gh-actions-configuration
 [gh-actions]
 python =
-  3.6: py36
   3.7: py37
   3.8: py38
   3.9: py39


### PR DESCRIPTION
`pick` replaced `options_map_func` with `Option` class: https://github.com/wong2/pick/releases/tag/v2.0.0 this breaks a lot of existing behavior.

This passes CI on py310 but faills on py36, probably because the version of pick being used is different. `pick<=1.6.0` only has `options_map_func` and `pick>=2.0.0` only has `Option`...