### PR TITLE
Access value inside pick.Option

### DIFF
--- a/agiocli/utils.py
+++ b/agiocli/utils.py
@@ -239,7 +239,7 @@ def get_course_smart(course_arg, client):
                 multiselect=False,
             )
             assert selected_courses
-            return selected_courses[0]
+            return selected_courses[0].value
 
     # Try to match a course
     matches = course_match(course_arg, courses)
@@ -389,7 +389,7 @@ def get_project_smart(project_arg, course_arg, client):
             multiselect=False,
         )
         assert selected_projects
-        return selected_projects[0]
+        return selected_projects[0].value
 
     # User provides strings, try to match a project
     matches = project_match(project_arg, projects)
@@ -585,7 +585,7 @@ def get_submission_smart(
             multiselect=False,
         )
         assert selected_submissions
-        return selected_submissions[0]
+        return selected_submissions[0].value
 
     # User provides string "last"
     if submission_arg == "last":

--- a/tests/test_courses.py
+++ b/tests/test_courses.py
@@ -8,6 +8,7 @@ import textwrap
 import click
 import click.testing
 import freezegun
+from pick import Option
 from agiocli.__main__ import main
 
 
@@ -55,7 +56,7 @@ def test_courses_empty(api_mock, mocker):
         'allowed_guest_domain': '@umich.edu',
         'last_modified': '2021-04-07T02:19:22.818992Z'
     }
-    mocker.patch("pick.pick", return_value=(course_109, 1))
+    mocker.patch("pick.pick", return_value=(Option(course_109, course_109), 1))
 
     # Run agio
     runner = click.testing.CliRunner()

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -103,8 +103,10 @@ def test_groups_empty(api_mock, mocker, constants):
     # These are constants in conftest.py.  Mock input "awdeorio", which selects
     # a group.
     mocker.patch("pick.pick", side_effect=[
-        (Option(constants["COURSE_109"], constants["COURSE_109"]), 1),  # First call to pick() selects course
-        (Option(constants["PROJECT_1005"], constants["PROJECT_1005"]), 0),  # Second call selects project
+        # First call to pick() selects course
+        (Option(constants["COURSE_109"], constants["COURSE_109"]), 1),
+        # Second call selects project
+        (Option(constants["PROJECT_1005"], constants["PROJECT_1005"]), 0),
     ])
     mocker.patch("builtins.input", return_value="awdeorio")
 

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -6,6 +6,7 @@ https://click.palletsprojects.com/en/8.0.x/testing/
 import json
 import click
 import click.testing
+from pick import Option
 from agiocli.__main__ import main
 
 
@@ -102,8 +103,8 @@ def test_groups_empty(api_mock, mocker, constants):
     # These are constants in conftest.py.  Mock input "awdeorio", which selects
     # a group.
     mocker.patch("pick.pick", side_effect=[
-        (constants["COURSE_109"], 1),  # First call to pick() selects course
-        (constants["PROJECT_1005"], 0),  # Second call selects project
+        (Option(constants["COURSE_109"], constants["COURSE_109"]), 1),  # First call to pick() selects course
+        (Option(constants["PROJECT_1005"], constants["PROJECT_1005"]), 0),  # Second call selects project
     ])
     mocker.patch("builtins.input", return_value="awdeorio")
 

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -9,6 +9,7 @@ import shlex
 import click
 import click.testing
 import utils
+from pick import Option
 from agiocli.__main__ import main
 
 
@@ -116,7 +117,7 @@ def test_projects_no_course(api_mock, mocker, constants):
     """
     # Mock user-selection menu, users selects course 109.  This constant is
     # defined in conftest.py
-    mocker.patch("pick.pick", return_value=(constants["COURSE_109"], 1))
+    mocker.patch("pick.pick", return_value=(Option(constants["COURSE_109"], constants["COURSE_109"]), 1))
 
     # Run agio
     runner = click.testing.CliRunner()
@@ -140,8 +141,8 @@ def test_projects_empty(api_mock, mocker, constants):
     # Mock user-selection menu, users selects course 109, then project 1005.
     # These constants are defined in conftest.py
     mocker.patch("pick.pick", side_effect=[
-        (constants["COURSE_109"], 1),  # First call to pick() selects course
-        (constants["PROJECT_1005"], 0),  # Second  call selects project
+        (Option(constants["COURSE_109"], constants["COURSE_109"]), 1),  # First call to pick() selects course
+        (Option(constants["PROJECT_1005"], constants["PROJECT_1005"]), 0),  # Second  call selects project
     ])
 
     # Run agio

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -117,7 +117,8 @@ def test_projects_no_course(api_mock, mocker, constants):
     """
     # Mock user-selection menu, users selects course 109.  This constant is
     # defined in conftest.py
-    mocker.patch("pick.pick", return_value=(Option(constants["COURSE_109"], constants["COURSE_109"]), 1))
+    mocker.patch("pick.pick", return_value=(
+        Option(constants["COURSE_109"], constants["COURSE_109"]), 1))
 
     # Run agio
     runner = click.testing.CliRunner()
@@ -141,8 +142,10 @@ def test_projects_empty(api_mock, mocker, constants):
     # Mock user-selection menu, users selects course 109, then project 1005.
     # These constants are defined in conftest.py
     mocker.patch("pick.pick", side_effect=[
-        (Option(constants["COURSE_109"], constants["COURSE_109"]), 1),  # First call to pick() selects course
-        (Option(constants["PROJECT_1005"], constants["PROJECT_1005"]), 0),  # Second  call selects project
+        # First call to pick() selects course
+        (Option(constants["COURSE_109"], constants["COURSE_109"]), 1),
+        # Second  call selects project
+        (Option(constants["PROJECT_1005"], constants["PROJECT_1005"]), 0),
     ])
 
     # Run agio

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -6,6 +6,7 @@ https://click.palletsprojects.com/en/8.0.x/testing/
 import json
 import click
 import click.testing
+from pick import Option
 from agiocli.__main__ import main
 
 
@@ -126,9 +127,9 @@ def test_submissions_empty(api_mock, mocker, constants):
     # then submission 1128572.  These are constants in conftest.py. Mock input
     # "awdeorio", which selects a group.
     mocker.patch("pick.pick", side_effect=[
-        (constants["COURSE_109"], 1),  # First call to pick() selects course
-        (constants["PROJECT_1005"], 0),  # Second call selects project
-        (constants["SUBMISSION_1128572"], 0),  # Third call selects submission
+        (Option(constants["COURSE_109"], constants["COURSE_109"]), 1),  # First call to pick() selects course
+        (Option(constants["PROJECT_1005"], constants["PROJECT_1005"]), 0),  # Second call selects project
+        (Option(constants["SUBMISSION_1128572"], constants["SUBMISSION_1128572"]), 0),  # Third call selects submission
     ])
     mocker.patch("builtins.input", return_value="awdeorio")
 

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -127,9 +127,13 @@ def test_submissions_empty(api_mock, mocker, constants):
     # then submission 1128572.  These are constants in conftest.py. Mock input
     # "awdeorio", which selects a group.
     mocker.patch("pick.pick", side_effect=[
-        (Option(constants["COURSE_109"], constants["COURSE_109"]), 1),  # First call to pick() selects course
-        (Option(constants["PROJECT_1005"], constants["PROJECT_1005"]), 0),  # Second call selects project
-        (Option(constants["SUBMISSION_1128572"], constants["SUBMISSION_1128572"]), 0),  # Third call selects submission
+        # First call to pick() selects course
+        (Option(constants["COURSE_109"], constants["COURSE_109"]), 1),
+        # Second call selects project
+        (Option(constants["PROJECT_1005"], constants["PROJECT_1005"]), 0),
+        # Third call selects submission
+        (Option(constants["SUBMISSION_1128572"],
+         constants["SUBMISSION_1128572"]), 0),
     ])
     mocker.patch("builtins.input", return_value="awdeorio")
 


### PR DESCRIPTION
#40 introduced a bug: 

```console
(env) jmapple@Justins-MacBook-Pro agio-cli % ./env/bin/agio groups  
# After picker for the course
Traceback (most recent call last):
  File "/Users/jmapple/Developer/eecs485-staff/agio-cli/./env/bin/agio", line 33, in <module>
    sys.exit(load_entry_point('agiocli', 'console_scripts', 'agio')())
  File "/Users/jmapple/Developer/eecs485-staff/agio-cli/env/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/jmapple/Developer/eecs485-staff/agio-cli/env/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/jmapple/Developer/eecs485-staff/agio-cli/env/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/jmapple/Developer/eecs485-staff/agio-cli/env/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/jmapple/Developer/eecs485-staff/agio-cli/env/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/jmapple/Developer/eecs485-staff/agio-cli/env/lib/python3.9/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/jmapple/Developer/eecs485-staff/agio-cli/agiocli/__main__.py", line 185, in groups
    group = utils.get_group_smart(group_arg, project_arg, course_arg, client)
  File "/Users/jmapple/Developer/eecs485-staff/agio-cli/agiocli/utils.py", line 458, in get_group_smart
    project = get_project_smart(project_arg, course_arg, client)
  File "/Users/jmapple/Developer/eecs485-staff/agio-cli/agiocli/utils.py", line 378, in get_project_smart
    projects = get_course_project_list(course, client)
  File "/Users/jmapple/Developer/eecs485-staff/agio-cli/agiocli/utils.py", line 357, in get_course_project_list
    projects = client.get(f"/api/courses/{course['pk']}/projects/")
TypeError: 'Option' object is not subscriptable
```

This is because we're returning `selected_courses[0]` which is now the `Option` and not a `dict`. 